### PR TITLE
Añadir enlace a la documentación y badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # `fsm`
 
 Finite State Machine library written in C.
+
+# LSEL 2025 Grupo 13 ceedling-tests
+
+[![Ceedling Testing](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/ceedling-tests.yaml/badge.svg)](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/ceedling-tests.yaml)
+
+# WebPage
+
+[![Web Page](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/webpage.yaml/badge.svg)](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/webpage.yaml)
+
+# buildPage
+
+[![pages-build-deployment](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/chenxinyu12138/lsel2025-13/actions/workflows/pages/pages-build-deployment)
+
+# Documentación del Proyecto
+
+Puedes consultar la documentación generada automáticamente en:
+
+[Ver documentación en línea](https://chenxinyu12138.github.io/lsel2025-13/)


### PR DESCRIPTION
- Se ha añadido el enlace a la documentación del proyecto generada automáticamente (GitHub Pages).
- Se han añadido los badges de los workflows:
  - Ceedling Testing
  - Web Page
  - GitHub Pages deployment